### PR TITLE
bug(EWCI-49): Fixed adding orders to send the request without order id, tracking number and design

### DIFF
--- a/src/main/java/com/wondacabinetinc/wondacabinetinc/businesslayer/OrderServiceImpl.java
+++ b/src/main/java/com/wondacabinetinc/wondacabinetinc/businesslayer/OrderServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 @Service
 public class OrderServiceImpl implements OrderService {
@@ -63,6 +64,11 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public Order addOrder(Order order) {
         try{
+            Random rand = new Random();
+            order.setOrderId(rand.nextInt());
+            order.setTrackingNo(rand.nextInt());
+            order.setOrderStatus("Awaiting Order");
+            order.setDesign("https://s2.q4cdn.com/498544986/files/doc_downloads/test.pdf");
             LOG.debug("Order Added: order with ID {} saved", order.getOrderId());
             return orderRepository.save(order);
         }

--- a/src/main/java/com/wondacabinetinc/wondacabinetinc/datalayer/Order.java
+++ b/src/main/java/com/wondacabinetinc/wondacabinetinc/datalayer/Order.java
@@ -2,27 +2,33 @@ package com.wondacabinetinc.wondacabinetinc.datalayer;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
 import javax.validation.constraints.Digits;
+import javax.validation.constraints.PositiveOrZero;
+import java.util.Random;
 
 @Entity
 @Table(name = "orders")
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@NoArgsConstructor
+@AllArgsConstructor
 public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="order_id")
+    @Column(name="order_id", unique = true, nullable = false)
     private Integer orderId;
 
-    @Column(name="orderStatus")
+    @Column(name="orderStatus", columnDefinition = "varchar(50) default 'Awaiting Order'", nullable = false)
     private String orderStatus;
 
-    @Column(name="trackingNo")
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Digits(integer = 6, fraction = 0)
-    private Long trackingNo;
+    @Column(name="trackingNo",unique = true)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @PositiveOrZero
+    private Integer trackingNo;
 
     @Column(name="design")
     private String design;
@@ -39,7 +45,9 @@ public class Order {
     @Column(name="handle_type")
     private String handleType;
 
-    public void setTrackingNo(Long trackingNo) {
+    public void setTrackingNo(Integer trackingNo) {
+        Random rand = new Random();
+        this.trackingNo = rand.nextInt(999999);
         this.trackingNo = trackingNo;
     }
 
@@ -75,42 +83,6 @@ public class Order {
         this.handleType = handleType;
     }
 
-    public Order(int orderId, String orderStatus, long trackingNo, String design) {
-        this.orderId = orderId;
-        this.orderStatus = orderStatus;
-        this.trackingNo = trackingNo;
-        this.design = design;
-    }
-
-    public Order(String orderStatus, long trackingNo, String design) {
-        this.orderStatus = orderStatus;
-        this.trackingNo = trackingNo;
-        this.design = design;
-    }
-
-    public Order(Integer orderId, String orderStatus, @Digits(integer = 6, fraction = 0) Long trackingNo, String design, String cabinetType, String color, String material, String handleType) {
-        this.orderId = orderId;
-        this.orderStatus = orderStatus;
-        this.trackingNo = trackingNo;
-        this.design = design;
-        this.cabinetType = cabinetType;
-        this.color = color;
-        this.material = material;
-        this.handleType = handleType;
-    }
-
-    public Order(String orderStatus, @Digits(integer = 6, fraction = 0) Long trackingNo, String design, String cabinetType, String color, String material, String handleType) {
-        this.orderStatus = orderStatus;
-        this.trackingNo = trackingNo;
-        this.design = design;
-        this.cabinetType = cabinetType;
-        this.color = color;
-        this.material = material;
-        this.handleType = handleType;
-    }
-
-    public Order() {
-    }
 
     public int getOrderId() {
         return orderId;
@@ -128,12 +100,13 @@ public class Order {
         this.orderStatus = orderStatus;
     }
 
-    public long getTrackingNo() {
+    public int getTrackingNo() {
         return trackingNo;
     }
 
-    public void setTrackingNo(long trackingNo) {
-        this.trackingNo = trackingNo;
+    public void setTrackingNo(int trackingNo) {
+        Random rand = new Random();
+        this.trackingNo = rand.nextInt(999999);
     }
 
     public String getDesign() {

--- a/src/test/java/com/wondacabinetinc/businesslayer/MailingServiceTest.java
+++ b/src/test/java/com/wondacabinetinc/businesslayer/MailingServiceTest.java
@@ -28,7 +28,7 @@ public class MailingServiceTest {
     @MockBean
     MailSenderService mailSenderService;
 
-    Order order = new Order(1,"Received", 123321, "Design");
+    Order order = new Order(1, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob");
 
     @BeforeEach
     void setUp() throws MessagingException {

--- a/src/test/java/com/wondacabinetinc/businesslayer/OrderServiceTest.java
+++ b/src/test/java/com/wondacabinetinc/businesslayer/OrderServiceTest.java
@@ -56,16 +56,16 @@ public class OrderServiceTest {
         int expected_length = 10;
 
         List<Order> orderList = new ArrayList<>();
-        orderList.add(new Order(1,"Received", 123321, "Design"));
-        orderList.add(new Order(2,"In Progress", 456647, "Design"));
-        orderList.add(new Order(3,"Design Received", 789789, "Design"));
-        orderList.add(new Order(4,"Awaiting Scheduling", 999999, "Design"));
-        orderList.add(new Order(5,"Shipped", 555555, "Design"));
-        orderList.add(new Order(6,"Cancelled", 333333, "Design"));
-        orderList.add(new Order(7,"Cancelled", 444444, "Design"));
-        orderList.add(new Order(8,"Closed", 777888, "Design"));
-        orderList.add(new Order(9,"Closed", 999000, "Design"));
-        orderList.add(new Order(10,"Closed", 334455, "Design"));
+        orderList.add(new Order(1, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(2, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(3, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(4, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(5, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(6, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(7, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(8, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(9, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(10, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
 
         when(orderResource.findAllOrders()).thenReturn(orderList);
 
@@ -81,9 +81,9 @@ public class OrderServiceTest {
         int expected_length = 3;
 
         List<Order> orderList = new ArrayList<>();
-        orderList.add(new Order(1,"Cancelled", 123321, "Design"));
-        orderList.add(new Order(2,"Cancelled", 456647, "Design"));
-        orderList.add(new Order(3,"Cancelled", 789789, "Design"));
+        orderList.add(new Order(1, "Cancelled",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(2, "Cancelled",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(3, "Cancelled",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
 
         when(orderService.getCancelledOrders()).thenReturn(orderList);
 
@@ -98,9 +98,9 @@ public class OrderServiceTest {
         int expected_length = 3;
 
         List<Order> orderList = new ArrayList<>();
-        orderList.add(new Order(1,"Awaiting Design", 123321, "Design"));
-        orderList.add(new Order(2,"Awaiting Design", 456647, "Design"));
-        orderList.add(new Order(3,"Awaiting Design", 789789, "Design"));
+        orderList.add(new Order(1, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(2, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
+        orderList.add(new Order(3, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob"));
 
         when(orderService.getNotCancelledOrders()).thenReturn(orderList);
 
@@ -115,7 +115,7 @@ public class OrderServiceTest {
     public void add_order(){
         int orderId = 1;
         Order order = new Order(orderId, "Done",
-                (long)555555, "Design",
+                555555, "Design",
                 "Kitchen Cabinet","White",
                 "Birch", "Circle");
 
@@ -132,8 +132,8 @@ public class OrderServiceTest {
     @DisplayName("Add an order null value")
     @Test
     public void add_order_throws_not_found_when_null_value(){
-        Order order = new Order("Done",
-                (long)555555, "Design",
+        Order order = new Order(null,"Done",
+                555555, "Design",
                 "Kitchen Cabinet","White",
                 "Birch", "Circle");
 
@@ -173,7 +173,7 @@ public class OrderServiceTest {
     @Test
     public void find_order_by_id(){
         Order order = new Order(1, "Done",
-                (long)555555, "Design",
+                555555, "Design",
                 "Kitchen Cabinet","White",
                 "Birch", "Circle");
 
@@ -204,7 +204,7 @@ public class OrderServiceTest {
     @DisplayName("Update order")
     @Test
     public void update_order(){
-        Order newOrder = new Order(1, "Received",(long)555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob");
+        Order newOrder = new Order(1, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob");
         when(orderRepository.findById(1)).thenReturn(Optional.of(newOrder));
 
         Optional<Order> retrieved = orderRepository.findById(1);
@@ -229,7 +229,7 @@ public class OrderServiceTest {
         int orderId = 100;
         String expectedMsg = "Order with Id: " + orderId + " not found";
 
-        Order newOrder = new Order(1, "Received",(long)555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob");
+        Order newOrder = new Order(1, "Received",555555, "Design", "Kitchen Cabinet", "Ivory", "Pine", "Knob");
 
         when(orderRepository.findById(Mockito.anyInt())).thenThrow(new NotFoundException());
 


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/EWCI-49?atlOrigin=eyJpIjoiMTA2NjQ2ZmE1MjU4NDNlZWE1ZTc5M2FlNTNhNzA5YTQiLCJwIjoiaiJ9

Changes: Add order used to require order id, design and tracking number to be entered, now the fields will be set automatically. 

![image](https://user-images.githubusercontent.com/61334330/151727009-ef894c29-9cba-487f-8751-c6fd79bd93b9.png)
